### PR TITLE
Adds non-object tests for schemas.

### DIFF
--- a/dist/maps.js
+++ b/dist/maps.js
@@ -1,10 +1,13 @@
 "use strict";
+var rulr_1 = require("rulr");
 var factory_1 = require("./factory");
-var map = function (keyRule, valueRule) { return function (data, path) {
-    var keys = Object.keys(data);
-    return keys.reduce(function (warnings, key) {
-        return warnings.concat(keyRule(key, path)).concat(valueRule(data[key], path.concat(key)));
-    }, []);
-}; };
+var map = function (keyRule, valueRule) {
+    return rulr_1.first(rulr_1.checkType(Object), function (data, path) {
+        var keys = Object.keys(data);
+        return keys.reduce(function (warnings, key) {
+            return warnings.concat(keyRule(key, path)).concat(valueRule(data[key], path.concat(key)));
+        }, []);
+    });
+};
 exports.extensions = map(factory_1.iri, factory_1.anyValue);
 exports.languageMap = map(factory_1.language, factory_1.stringValue);

--- a/dist/tests/helpers/objectTypeFactory.js
+++ b/dist/tests/helpers/objectTypeFactory.js
@@ -1,7 +1,9 @@
 "use strict";
 require("mocha");
+var itsInvalid_1 = require("../itsInvalid");
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (types, defaultType, test) {
+    itsInvalid_1.default(10, 'not an object', test);
     Object.keys(types).forEach(function (type) {
         describe("Object Type: " + type, function () {
             types[type](function (data, valid) {

--- a/dist/tests/maps/extensions.js
+++ b/dist/tests/maps/extensions.js
@@ -6,6 +6,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     itsInvalid_1.default({
         http: 'test'
     }, 'containing invalid keys', test);

--- a/dist/tests/maps/languageMap.js
+++ b/dist/tests/maps/languageMap.js
@@ -6,6 +6,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     itsInvalid_1.default({
         '-': 'test'
     }, 'containing invalid keys', test);

--- a/dist/tests/schemaRules/account.js
+++ b/dist/tests/schemaRules/account.js
@@ -1,5 +1,6 @@
 "use strict";
 var describeRequiredProp_1 = require("../describeRequiredProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     homePage: 'http://www.example.com',
@@ -7,6 +8,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeRequiredProp_1.default('homePage', factory_1.iri, validData, test);
     describeRequiredProp_1.default('name', factory_1.stringValue, validData, test);
 };

--- a/dist/tests/schemaRules/activity.js
+++ b/dist/tests/schemaRules/activity.js
@@ -1,6 +1,7 @@
 "use strict";
 var describeRequiredProp_1 = require("../describeRequiredProp");
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     objectType: 'Activity',
@@ -9,6 +10,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeRequiredProp_1.default('id', factory_1.iri, validData, test);
     describeOptionalProp_1.default('definition', factory_1.definition, validData, test);
 };

--- a/dist/tests/schemaRules/attachment.js
+++ b/dist/tests/schemaRules/attachment.js
@@ -1,6 +1,7 @@
 "use strict";
 var describeRequiredProp_1 = require("../describeRequiredProp");
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     usageType: 'http://www.example.com',
@@ -13,6 +14,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeRequiredProp_1.default('usageType', factory_1.iri, validData, test);
     describeRequiredProp_1.default('display', factory_1.languageMap, validData, test);
     describeOptionalProp_1.default('description', factory_1.languageMap, validData, test);

--- a/dist/tests/schemaRules/authority.js
+++ b/dist/tests/schemaRules/authority.js
@@ -8,6 +8,7 @@ var agentMember = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     itsInvalid_1.default({
         objectType: 'Group',
         member: [],

--- a/dist/tests/schemaRules/context.js
+++ b/dist/tests/schemaRules/context.js
@@ -1,5 +1,6 @@
 "use strict";
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     registration: 'd0310d1c-65fe-4b59-9d4f-c56de054243a',
@@ -23,6 +24,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeOptionalProp_1.default('registration', factory_1.uuid, validData, test);
     describeOptionalProp_1.default('instructor', factory_1.actor, validData, test);
     describeOptionalProp_1.default('team', factory_1.group, validData, test);

--- a/dist/tests/schemaRules/contextActivities.js
+++ b/dist/tests/schemaRules/contextActivities.js
@@ -1,5 +1,6 @@
 "use strict";
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var collection_1 = require("../helpers/collection");
 var factory_1 = require("../factory");
 var validData = {
@@ -11,6 +12,7 @@ var validData = {
 var activities = collection_1.default(factory_1.activity);
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeOptionalProp_1.default('parent', activities, validData, test);
     describeOptionalProp_1.default('category', activities, validData, test);
     describeOptionalProp_1.default('grouping', activities, validData, test);

--- a/dist/tests/schemaRules/group.js
+++ b/dist/tests/schemaRules/group.js
@@ -1,10 +1,12 @@
 "use strict";
 require("mocha");
+var itsInvalid_1 = require("../itsInvalid");
 var agentSchema_1 = require("../helpers/agentSchema");
 var describeMemberProp_1 = require("../describeMemberProp");
 var factory_1 = require("../factory");
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     factory_1.subGroup(test);
     describeMemberProp_1.default(factory_1.subGroup, test);
     agentSchema_1.default(test);

--- a/dist/tests/schemaRules/interactionComponent.js
+++ b/dist/tests/schemaRules/interactionComponent.js
@@ -1,6 +1,7 @@
 "use strict";
 var describeRequiredProp_1 = require("../describeRequiredProp");
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     id: 'test',
@@ -8,6 +9,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeRequiredProp_1.default('id', factory_1.stringValue, validData, test);
     describeOptionalProp_1.default('description', factory_1.languageMap, validData, test);
 };

--- a/dist/tests/schemaRules/result.js
+++ b/dist/tests/schemaRules/result.js
@@ -1,5 +1,6 @@
 "use strict";
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     score: {},
@@ -11,6 +12,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeOptionalProp_1.default('score', factory_1.score, validData, test);
     describeOptionalProp_1.default('success', factory_1.booleanValue, validData, test);
     describeOptionalProp_1.default('completion', factory_1.booleanValue, validData, test);

--- a/dist/tests/schemaRules/score.js
+++ b/dist/tests/schemaRules/score.js
@@ -1,5 +1,6 @@
 "use strict";
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     scaled: 0,
@@ -9,6 +10,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeOptionalProp_1.default('scaled', factory_1.scaledValue, validData, test);
     describeOptionalProp_1.default('raw', factory_1.numberValue, validData, test);
     describeOptionalProp_1.default('min', factory_1.numberValue, validData, test);

--- a/dist/tests/schemaRules/statement.js
+++ b/dist/tests/schemaRules/statement.js
@@ -1,11 +1,13 @@
 "use strict";
 var describeRequiredProp_1 = require("../describeRequiredProp");
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var statementSchema_1 = require("../helpers/statementSchema");
 var validStatementData_1 = require("../helpers/validStatementData");
 var factory_1 = require("../factory");
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeOptionalProp_1.default('id', factory_1.uuid, validStatementData_1.default, test);
     describeOptionalProp_1.default('stored', factory_1.timestamp, validStatementData_1.default, test);
     describeOptionalProp_1.default('authority', factory_1.authority, validStatementData_1.default, test);

--- a/dist/tests/schemaRules/statementRef.js
+++ b/dist/tests/schemaRules/statementRef.js
@@ -1,5 +1,6 @@
 "use strict";
 var describeRequiredProp_1 = require("../describeRequiredProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     objectType: 'StatementRef',
@@ -7,5 +8,6 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeRequiredProp_1.default('id', factory_1.uuid, validData, test);
 };

--- a/dist/tests/schemaRules/subGroup.js
+++ b/dist/tests/schemaRules/subGroup.js
@@ -6,6 +6,7 @@ var agentSchema_1 = require("../helpers/agentSchema");
 var factory_1 = require("../factory");
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     itsInvalid_1.default({
         objectType: 'Group',
         name: 'Test',

--- a/dist/tests/schemaRules/subStatement.js
+++ b/dist/tests/schemaRules/subStatement.js
@@ -6,6 +6,7 @@ var validStatementData_1 = require("../helpers/validStatementData");
 var factory_1 = require("../factory");
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     itsInvalid_1.default(Object.assign({}, validStatementData_1.default, {
         object: Object.assign({}, validStatementData_1.default, {
             objectType: 'SubStatement',

--- a/dist/tests/schemaRules/verb.js
+++ b/dist/tests/schemaRules/verb.js
@@ -1,6 +1,7 @@
 "use strict";
 var describeRequiredProp_1 = require("../describeRequiredProp");
 var describeOptionalProp_1 = require("../describeOptionalProp");
+var itsInvalid_1 = require("../itsInvalid");
 var factory_1 = require("../factory");
 var validData = {
     id: 'http://www.example.com',
@@ -8,6 +9,7 @@ var validData = {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = function (test) {
+    itsInvalid_1.default(10, 'not an object', test);
     describeRequiredProp_1.default('id', factory_1.iri, validData, test);
     describeOptionalProp_1.default('display', factory_1.languageMap, validData, test);
 };

--- a/src/maps.ts
+++ b/src/maps.ts
@@ -1,14 +1,15 @@
-import { Rule, Warning } from 'rulr';
+import { Rule, Warning, first, checkType } from 'rulr';
 import { anyValue, stringValue, iri, language } from './factory';
 
-const map = (keyRule: Rule, valueRule: Rule): Rule => (data, path) => {
-  const keys = Object.keys(data);
-  return keys.reduce((warnings: Warning[], key: string) =>
-    warnings.concat(keyRule(key, path)).concat(
-      valueRule(data[key], path.concat(key))
-    )
-  , []);
-};
+const map = (keyRule: Rule, valueRule: Rule): Rule =>
+  first(checkType(Object), (data, path) => {
+    const keys = Object.keys(data);
+    return keys.reduce((warnings: Warning[], key: string) =>
+      warnings.concat(keyRule(key, path)).concat(
+        valueRule(data[key], path.concat(key))
+      )
+    , []);
+  });
 
 export const extensions = map(iri, anyValue);
 export const languageMap = map(language, stringValue);

--- a/src/tests/helpers/objectTypeFactory.ts
+++ b/src/tests/helpers/objectTypeFactory.ts
@@ -1,10 +1,12 @@
 import 'mocha';
 import Test from '../helpers/test';
+import itsInvalid from '../itsInvalid';
 
 export type Type = (test: Test) => any;
 export type Types = {[key: string]: Type};
 
 export default (types: Types, defaultType: string, test: Test): void => {
+  itsInvalid(10, 'not an object', test);
   Object.keys(types).forEach((type: string) => {
     describe(`Object Type: ${type}`, () => {
       types[type]((data: any, valid: boolean): any => {

--- a/src/tests/maps/extensions.ts
+++ b/src/tests/maps/extensions.ts
@@ -7,6 +7,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   itsInvalid({
     http: 'test'
   }, 'containing invalid keys', test);

--- a/src/tests/maps/languageMap.ts
+++ b/src/tests/maps/languageMap.ts
@@ -7,6 +7,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   itsInvalid({
     '-': 'test'
   }, 'containing invalid keys', test);

--- a/src/tests/schemaRules/account.ts
+++ b/src/tests/schemaRules/account.ts
@@ -1,5 +1,6 @@
 import Test from '../helpers/test';
 import describeRequiredProp from '../describeRequiredProp';
+import itsInvalid from '../itsInvalid';
 import { iri, stringValue } from '../factory';
 
 const validData = {
@@ -8,6 +9,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeRequiredProp('homePage', iri, validData, test);
   describeRequiredProp('name', stringValue, validData, test);
 };

--- a/src/tests/schemaRules/activity.ts
+++ b/src/tests/schemaRules/activity.ts
@@ -1,6 +1,7 @@
 import Test from '../helpers/test';
 import describeRequiredProp from '../describeRequiredProp';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import { iri, definition } from '../factory';
 
 const validData = {
@@ -10,6 +11,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeRequiredProp('id', iri, validData, test);
   describeOptionalProp('definition', definition, validData, test);
 };

--- a/src/tests/schemaRules/attachment.ts
+++ b/src/tests/schemaRules/attachment.ts
@@ -1,6 +1,7 @@
 import Test from '../helpers/test';
 import describeRequiredProp from '../describeRequiredProp';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import { iri, languageMap, imt, integerValue, stringValue } from '../factory';
 
 const validData = {
@@ -14,6 +15,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeRequiredProp('usageType', iri, validData, test);
   describeRequiredProp('display', languageMap, validData, test);
   describeOptionalProp('description', languageMap, validData, test);

--- a/src/tests/schemaRules/authority.ts
+++ b/src/tests/schemaRules/authority.ts
@@ -9,6 +9,7 @@ const agentMember = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   itsInvalid({
     objectType: 'Group',
     member: [],

--- a/src/tests/schemaRules/context.ts
+++ b/src/tests/schemaRules/context.ts
@@ -1,5 +1,6 @@
 import Test from '../helpers/test';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import {
   uuid,
   actor,
@@ -33,6 +34,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeOptionalProp('registration', uuid, validData, test);
   describeOptionalProp('instructor', actor, validData, test);
   describeOptionalProp('team', group, validData, test);

--- a/src/tests/schemaRules/contextActivities.ts
+++ b/src/tests/schemaRules/contextActivities.ts
@@ -1,5 +1,6 @@
 import Test from '../helpers/test';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import collection from '../helpers/collection';
 import { activity } from '../factory';
 
@@ -13,6 +14,7 @@ const validData = {
 const activities = collection(activity);
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeOptionalProp('parent', activities, validData, test);
   describeOptionalProp('category', activities, validData, test);
   describeOptionalProp('grouping', activities, validData, test);

--- a/src/tests/schemaRules/group.ts
+++ b/src/tests/schemaRules/group.ts
@@ -1,10 +1,12 @@
 import 'mocha';
 import Test from '../helpers/test';
+import itsInvalid from '../itsInvalid';
 import agentSchema from '../helpers/agentSchema';
 import describeMemberProp from '../describeMemberProp';
 import { subGroup } from '../factory';
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   subGroup(test);
   describeMemberProp(subGroup, test);
   agentSchema(test);

--- a/src/tests/schemaRules/interactionComponent.ts
+++ b/src/tests/schemaRules/interactionComponent.ts
@@ -1,6 +1,7 @@
 import Test from '../helpers/test';
 import describeRequiredProp from '../describeRequiredProp';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import { stringValue, languageMap } from '../factory';
 
 const validData = {
@@ -9,6 +10,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeRequiredProp('id', stringValue, validData, test);
   describeOptionalProp('description', languageMap, validData, test);
 };

--- a/src/tests/schemaRules/result.ts
+++ b/src/tests/schemaRules/result.ts
@@ -1,5 +1,6 @@
 import Test from '../helpers/test';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import {
   score,
   booleanValue,
@@ -18,6 +19,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeOptionalProp('score', score, validData, test);
   describeOptionalProp('success', booleanValue, validData, test);
   describeOptionalProp('completion', booleanValue, validData, test);

--- a/src/tests/schemaRules/score.ts
+++ b/src/tests/schemaRules/score.ts
@@ -1,5 +1,6 @@
 import Test from '../helpers/test';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import { scaledValue, numberValue } from '../factory';
 
 const validData = {
@@ -10,6 +11,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeOptionalProp('scaled', scaledValue, validData, test);
   describeOptionalProp('raw', numberValue, validData, test);
   describeOptionalProp('min', numberValue, validData, test);

--- a/src/tests/schemaRules/statement.ts
+++ b/src/tests/schemaRules/statement.ts
@@ -1,11 +1,13 @@
 import Test from '../helpers/test';
 import describeRequiredProp from '../describeRequiredProp';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import statementSchema from '../helpers/statementSchema';
 import validStatementData from '../helpers/validStatementData';
 import { uuid, timestamp, authority, version, object } from '../factory';
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeOptionalProp('id', uuid, validStatementData, test);
   describeOptionalProp('stored', timestamp, validStatementData, test);
   describeOptionalProp('authority', authority, validStatementData, test);

--- a/src/tests/schemaRules/statementRef.ts
+++ b/src/tests/schemaRules/statementRef.ts
@@ -1,5 +1,6 @@
 import Test from '../helpers/test';
 import describeRequiredProp from '../describeRequiredProp';
+import itsInvalid from '../itsInvalid';
 import { uuid } from '../factory';
 
 const validData = {
@@ -8,5 +9,6 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeRequiredProp('id', uuid, validData, test);
 };

--- a/src/tests/schemaRules/subGroup.ts
+++ b/src/tests/schemaRules/subGroup.ts
@@ -6,6 +6,7 @@ import agentSchema from '../helpers/agentSchema';
 import { agent } from '../factory';
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   itsInvalid({
     objectType: 'Group',
     name: 'Test',

--- a/src/tests/schemaRules/subStatement.ts
+++ b/src/tests/schemaRules/subStatement.ts
@@ -6,6 +6,7 @@ import validStatementData from '../helpers/validStatementData';
 import { subStatementObject } from '../factory';
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   itsInvalid(Object.assign({}, validStatementData, {
     object: Object.assign({}, validStatementData, {
       objectType: 'SubStatement',

--- a/src/tests/schemaRules/verb.ts
+++ b/src/tests/schemaRules/verb.ts
@@ -1,6 +1,7 @@
 import Test from '../helpers/test';
 import describeRequiredProp from '../describeRequiredProp';
 import describeOptionalProp from '../describeOptionalProp';
+import itsInvalid from '../itsInvalid';
 import { iri, languageMap } from '../factory';
 
 const validData = {
@@ -9,6 +10,7 @@ const validData = {
 };
 
 export default (test: Test) => {
+  itsInvalid(10, 'not an object', test);
   describeRequiredProp('id', iri, validData, test);
   describeOptionalProp('display', languageMap, validData, test);
 };


### PR DESCRIPTION
Actually fixes an issue in maps where it didn't throw a warning when the map wasn't an object.